### PR TITLE
Add play state toggle to home page (WIP)

### DIFF
--- a/_pug/index.pug
+++ b/_pug/index.pug
@@ -34,6 +34,7 @@ block content
     include ../_assets/images/scene5-page1.svg
     include ../_assets/images/scene5-page2.svg
     include ../_assets/images/scene5-page3.svg
+    button.playPause(onclick="document.documentElement.classList.toggle('play')") play/pause
     .screenreader
       p This page has a unique visual experience. As you resize the browser window, the artwork animates so it feels like you are moving forward or backward through space.
       p From widest to narrowest sizes, this is the experience:

--- a/_styl/pages/home.styl
+++ b/_styl/pages/home.styl
@@ -34,6 +34,19 @@
   .main-footer
     display: none
 
+  .playPause
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 99;
+
+html.play *
+  animation-delay: calc(-10s * var(--tt-bind) / var(--tt-max))
+  animation-duration: 10s
+  animation-play-state: running
+  animation-direction: alternate
+  animation-iteration-count: infinite
+
 @keyframes body-bg
   0%, 40%
     background-color: #333
@@ -69,6 +82,8 @@
     left: 50%
     top: 50%
     transform: translate(-50%,-50%)
+    html.play &
+      display: block !important
 
   //----------------------
   // SCENE 0 - SPACE PIZZA


### PR DESCRIPTION
This adds a play state toggle to the home page enabling you to watch the full animation even if you are unable to resize your viewport.

Notes
- The play state toggle is not styled
- This forces everything to be `display: block` when in play mode, causing artifacts. When this style isn’t added then segments of the animation are missing.