### PR TITLE
Fixes the overflow value

### DIFF
--- a/_styl/components/type.styl
+++ b/_styl/components/type.styl
@@ -70,7 +70,7 @@ pre, code
 
 pre
   white-space: pre-wrap
-  overflow: scroll
+  overflow: auto
 pre code
   @media screen and (max-width: 400px)
     font-size: .85rem

--- a/_styl/pages/gifs.styl
+++ b/_styl/pages/gifs.styl
@@ -25,7 +25,7 @@
   code
     padding: .5em 1em
     display: block
-    overflow: scroll
+    overflow: auto
     background-color: var(--btn-bg)
     color: var(--text-color)
     border: $ui-border


### PR DESCRIPTION
The `overflow: scroll` is almost always useless and in 99% of cases can be replaced with `overflow: auto`. Otherwise, if the OS have the scrollbars always visible, `scroll` could lead to some unintended design issues.

I did fix this for the most recent design, but did not go through the archived ones (as I don't know if you want to keep them in the state they were, or if it is ok to fix issues like that in them).

before | after
-|-
<img width="744" alt="Screenshot 2023-03-30 at 23 50 43" src="https://user-images.githubusercontent.com/177485/228972659-f59dad46-080a-4864-bf3c-1fa5f71643ec.png"> | <img width="744" alt="Screenshot 2023-03-30 at 23 51 24" src="https://user-images.githubusercontent.com/177485/228972662-e229064d-2c9c-4f52-b6b2-f176aaa6fee5.png">
<img width="614" alt="Screenshot 2023-03-30 at 23 49 46" src="https://user-images.githubusercontent.com/177485/228972674-86a0c1d5-0363-41ad-800c-681c1ff443fe.png"> | <img width="614" alt="Screenshot 2023-03-30 at 23 50 18" src="https://user-images.githubusercontent.com/177485/228972676-fb40770f-44db-49b9-8720-d314809545b9.png">

